### PR TITLE
test: 기존 도메인 테스트 개선 및 의존성 수정

### DIFF
--- a/src/test/java/com/be90z/domain/challenge/entity/ChallengeTest.java
+++ b/src/test/java/com/be90z/domain/challenge/entity/ChallengeTest.java
@@ -1,0 +1,92 @@
+package com.be90z.domain.challenge.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ChallengeTest {
+
+    @Test
+    @DisplayName("챌린지 생성 시 필수 값이 설정되어야 한다")
+    void createChallenge() {
+        // given
+        String challengeName = "다이어트 챌린지";
+        String challengeDescription = "건강한 다이어트를 위한 챌린지";
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = LocalDateTime.now().plusDays(30);
+        
+        // when
+        Challenge challenge = Challenge.builder()
+                .challengeName(challengeName)
+                .challengeDescription(challengeDescription)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+        
+        // then
+        assertThat(challenge.getChallengeName()).isEqualTo(challengeName);
+        assertThat(challenge.getChallengeDescription()).isEqualTo(challengeDescription);
+        assertThat(challenge.getStartDate()).isEqualTo(startDate);
+        assertThat(challenge.getEndDate()).isEqualTo(endDate);
+        assertThat(challenge.getChallengeStatus()).isEqualTo(ChallengeStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("챌린지명이 null일 경우 예외가 발생한다")
+    void createChallengeWithNullName() {
+        // given & when & then
+        assertThatThrownBy(() -> Challenge.builder()
+                .challengeName(null)
+                .challengeDescription("설명")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Challenge name cannot be null");
+    }
+
+    @Test
+    @DisplayName("챌린지 설명이 null일 경우 예외가 발생한다")
+    void createChallengeWithNullDescription() {
+        // given & when & then
+        assertThatThrownBy(() -> Challenge.builder()
+                .challengeName("챌린지명")
+                .challengeDescription(null)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Challenge description cannot be null");
+    }
+
+    @Test
+    @DisplayName("시작일이 null일 경우 예외가 발생한다")
+    void createChallengeWithNullStartDate() {
+        // given & when & then
+        assertThatThrownBy(() -> Challenge.builder()
+                .challengeName("챌린지명")
+                .challengeDescription("설명")
+                .startDate(null)
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Start date cannot be null");
+    }
+
+    @Test
+    @DisplayName("종료일이 null일 경우 예외가 발생한다")
+    void createChallengeWithNullEndDate() {
+        // given & when & then
+        assertThatThrownBy(() -> Challenge.builder()
+                .challengeName("챌린지명")
+                .challengeDescription("설명")
+                .startDate(LocalDateTime.now())
+                .endDate(null)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("End date cannot be null");
+    }
+}

--- a/src/test/java/com/be90z/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.be90z.domain.challenge.repository;
+
+import com.be90z.domain.challenge.entity.Challenge;
+import com.be90z.domain.challenge.entity.ChallengeStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+class ChallengeRepositoryTest {
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Test
+    @DisplayName("챌린지 상태로 조회")
+    void findByChallengeStatus() {
+        // given
+        Challenge activeChallenge = Challenge.builder()
+                .challengeName("활성 챌린지")
+                .challengeDescription("활성 상태의 챌린지")
+                .challengeStatus(ChallengeStatus.ACTIVE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        Challenge completedChallenge = Challenge.builder()
+                .challengeName("완료 챌린지")
+                .challengeDescription("완료된 챌린지")
+                .challengeStatus(ChallengeStatus.COMPLETED)
+                .startDate(LocalDateTime.now().minusDays(30))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .build();
+        
+        challengeRepository.save(activeChallenge);
+        challengeRepository.save(completedChallenge);
+        
+        // when
+        List<Challenge> activeChallenges = challengeRepository.findByChallengeStatus(ChallengeStatus.ACTIVE);
+        
+        // then
+        assertThat(activeChallenges).hasSize(1);
+        assertThat(activeChallenges.get(0).getChallengeName()).isEqualTo("활성 챌린지");
+    }
+
+    @Test
+    @DisplayName("현재 진행 중인 활성 챌린지 조회")
+    void findActiveChallengesAtDate() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        
+        Challenge currentChallenge = Challenge.builder()
+                .challengeName("현재 진행 중 챌린지")
+                .challengeDescription("현재 진행 중인 챌린지")
+                .challengeStatus(ChallengeStatus.ACTIVE)
+                .startDate(now.minusDays(1))
+                .endDate(now.plusDays(29))
+                .build();
+        
+        Challenge futureChallenge = Challenge.builder()
+                .challengeName("미래 챌린지")
+                .challengeDescription("미래의 챌린지")
+                .challengeStatus(ChallengeStatus.ACTIVE)
+                .startDate(now.plusDays(1))
+                .endDate(now.plusDays(31))
+                .build();
+        
+        challengeRepository.save(currentChallenge);
+        challengeRepository.save(futureChallenge);
+        
+        // when
+        List<Challenge> activeChallenges = challengeRepository.findActiveChallengesAtDate(now, ChallengeStatus.ACTIVE);
+        
+        // then
+        assertThat(activeChallenges).hasSize(1);
+        assertThat(activeChallenges.get(0).getChallengeName()).isEqualTo("현재 진행 중 챌린지");
+    }
+}

--- a/src/test/java/com/be90z/domain/mission/entity/MissionTest.java
+++ b/src/test/java/com/be90z/domain/mission/entity/MissionTest.java
@@ -1,0 +1,119 @@
+package com.be90z.domain.mission.entity;
+
+import com.be90z.domain.challenge.entity.Challenge;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+@DisplayName("Mission 엔티티 테스트")
+class MissionTest {
+
+    @Test
+    @DisplayName("Mission 엔티티 생성 테스트")
+    void createMission() {
+        // given
+        Challenge challenge = Challenge.builder()
+                .challengeName("다이어트 챌린지")
+                .challengeDescription("건강한 다이어트를 위한 챌린지")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        Long missionCode = 1L;
+        String missionName = "일일 운동하기";
+        String missionContent = "하루 30분 이상 운동하기";
+        MissionStatus missionStatus = MissionStatus.ACTIVE;
+        Integer missionMax = 100;
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = LocalDateTime.now().plusDays(30);
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // when
+        Mission mission = Mission.builder()
+                .missionCode(missionCode)
+                .challenge(challenge)
+                .missionName(missionName)
+                .missionContent(missionContent)
+                .missionStatus(missionStatus)
+                .missionMax(missionMax)
+                .startDate(startDate)
+                .endDate(endDate)
+                .createdAt(createdAt)
+                .build();
+
+        // then
+        assertThat(mission.getMissionCode()).isEqualTo(missionCode);
+        assertThat(mission.getChallenge()).isEqualTo(challenge);
+        assertThat(mission.getMissionName()).isEqualTo(missionName);
+        assertThat(mission.getMissionContent()).isEqualTo(missionContent);
+        assertThat(mission.getMissionStatus()).isEqualTo(missionStatus);
+        assertThat(mission.getMissionMax()).isEqualTo(missionMax);
+        assertThat(mission.getStartDate()).isEqualTo(startDate);
+        assertThat(mission.getEndDate()).isEqualTo(endDate);
+        assertThat(mission.getCreatedAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("Mission 필수 필드 검증")
+    void validateRequiredFields() {
+        // given
+        Challenge challenge = Challenge.builder()
+                .challengeName("테스트 챌린지")
+                .challengeDescription("테스트 설명")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        // when & then
+        assertThatThrownBy(() -> {
+            Mission.builder()
+                    .challenge(challenge)
+                    .missionContent("테스트 미션")
+                    .missionStatus(MissionStatus.ACTIVE)
+                    // missionName 누락
+                    .build();
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Mission name cannot be null");
+    }
+
+    @Test
+    @DisplayName("Mission과 Challenge 관계 테스트")
+    void missionChallengeRelationship() {
+        // given
+        Challenge challenge = Challenge.builder()
+                .challengeName("다이어트 챌린지")
+                .challengeDescription("건강한 다이어트를 위한 챌린지")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .build();
+        
+        // when
+        Mission mission = Mission.builder()
+                .challenge(challenge)
+                .missionName("물 8잔 마시기")
+                .missionContent("하루에 물을 8잔 이상 마시기")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+        
+        // then
+        assertThat(mission.getChallenge()).isEqualTo(challenge);
+    }
+
+    @Test
+    @DisplayName("챌린지가 null일 경우 예외가 발생한다")
+    void createMissionWithNullChallenge() {
+        // given & when & then
+        assertThatThrownBy(() -> Mission.builder()
+                .challenge(null)
+                .missionName("미션명")
+                .missionContent("내용")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Challenge cannot be null");
+    }
+}

--- a/src/test/java/com/be90z/domain/mission/repository/MissionParticipationRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/mission/repository/MissionParticipationRepositoryTest.java
@@ -1,0 +1,171 @@
+package com.be90z.domain.mission.repository;
+
+import com.be90z.domain.challenge.entity.Challenge;
+import com.be90z.domain.mission.entity.Mission;
+import com.be90z.domain.mission.entity.MissionParticipation;
+import com.be90z.domain.mission.entity.MissionStatus;
+import com.be90z.domain.mission.entity.ParticipateStatus;
+import com.be90z.domain.user.entity.User;
+import com.be90z.domain.user.entity.UserAuthority;
+import com.be90z.domain.user.entity.Gender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@DisplayName("MissionParticipationRepository 테스트")
+class MissionParticipationRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private MissionParticipationRepository participationRepository;
+
+    @Test
+    @DisplayName("사용자별 미션 참여 조회")
+    void findByUser() {
+        // given
+        User user = User.builder()
+                .provider("kakao")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .gender(Gender.WOMAN)
+                .birth(1990)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        Challenge challenge = Challenge.builder()
+                .challengeName("테스트 챌린지")
+                .challengeDescription("테스트 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().plusDays(25))
+                .createdAt(LocalDateTime.now().minusDays(5))
+                .build();
+        entityManager.persistAndFlush(challenge);
+
+        Mission mission = Mission.builder()
+                .missionCode(1L)
+                .challenge(challenge)
+                .missionName("테스트 미션")
+                .missionContent("테스트 미션 내용")
+                .missionStatus(MissionStatus.ACTIVE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .createdAt(LocalDateTime.now())
+                .build();
+        entityManager.persistAndFlush(mission);
+
+        MissionParticipation participation = MissionParticipation.builder()
+                .participateCode(1L)
+                .participateStatus(ParticipateStatus.PART_COMPLETE)
+                .user(user)
+                .mission(mission)
+                .build();
+        entityManager.persistAndFlush(participation);
+
+        // when
+        List<MissionParticipation> participations = participationRepository.findByUser(user);
+
+        // then
+        assertThat(participations).hasSize(1);
+        assertThat(participations.get(0).getUser()).isEqualTo(user);
+        assertThat(participations.get(0).getMission()).isEqualTo(mission);
+    }
+
+    @Test
+    @DisplayName("사용자와 미션으로 참여 정보 조회")
+    void findByUserAndMission() {
+        // given
+        User user = User.builder()
+                .provider("kakao")
+                .nickname("테스트유저2")
+                .email("test2@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .gender(Gender.MAN)
+                .birth(1985)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        Mission mission = Mission.builder()
+                .missionCode(2L)
+                .missionName("테스트 미션2")
+                .missionContent("테스트 미션2 내용")
+                .missionStatus(MissionStatus.ACTIVE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .createdAt(LocalDateTime.now())
+                .build();
+        entityManager.persistAndFlush(mission);
+
+        MissionParticipation participation = MissionParticipation.builder()
+                .participateCode(2L)
+                .participateStatus(ParticipateStatus.PART_BEFORE)
+                .user(user)
+                .mission(mission)
+                .build();
+        entityManager.persistAndFlush(participation);
+
+        // when
+        Optional<MissionParticipation> found = participationRepository.findByUserAndMission(user, mission);
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getParticipateStatus()).isEqualTo(ParticipateStatus.PART_BEFORE);
+    }
+
+    @Test
+    @DisplayName("사용자의 완료된 참여 조회")
+    void findCompletedParticipationsByUser() {
+        // given
+        User user = User.builder()
+                .provider("kakao")
+                .nickname("완료유저")
+                .email("complete@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .gender(Gender.WOMAN)
+                .birth(1992)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        Mission mission = Mission.builder()
+                .missionCode(3L)
+                .missionName("완료된 미션")
+                .missionContent("완료된 미션 내용")
+                .missionStatus(MissionStatus.COMPLETED)
+                .startDate(LocalDateTime.now().minusDays(30))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .createdAt(LocalDateTime.now().minusDays(30))
+                .build();
+        entityManager.persistAndFlush(mission);
+
+        MissionParticipation participation = MissionParticipation.builder()
+                .participateCode(3L)
+                .participateStatus(ParticipateStatus.PART_COMPLETE)
+                .user(user)
+                .mission(mission)
+                .build();
+        entityManager.persistAndFlush(participation);
+
+        // when
+        List<MissionParticipation> completedParticipations = 
+                participationRepository.findCompletedParticipationsByUser(user);
+
+        // then
+        assertThat(completedParticipations).hasSize(1);
+        assertThat(completedParticipations.get(0).getParticipateStatus())
+                .isEqualTo(ParticipateStatus.PART_COMPLETE);
+    }
+}

--- a/src/test/java/com/be90z/domain/mission/repository/MissionParticipationRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/mission/repository/MissionParticipationRepositoryTest.java
@@ -98,8 +98,18 @@ class MissionParticipationRepositoryTest {
                 .build();
         entityManager.persistAndFlush(user);
 
+        Challenge challenge2 = Challenge.builder()
+                .challengeName("테스트 챌린지2")
+                .challengeDescription("테스트 챌린지2 설명")
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().plusDays(25))
+                .createdAt(LocalDateTime.now().minusDays(5))
+                .build();
+        entityManager.persistAndFlush(challenge2);
+
         Mission mission = Mission.builder()
                 .missionCode(2L)
+                .challenge(challenge2)
                 .missionName("테스트 미션2")
                 .missionContent("테스트 미션2 내용")
                 .missionStatus(MissionStatus.ACTIVE)
@@ -140,8 +150,18 @@ class MissionParticipationRepositoryTest {
                 .build();
         entityManager.persistAndFlush(user);
 
+        Challenge challenge3 = Challenge.builder()
+                .challengeName("완료된 챌린지")
+                .challengeDescription("완료된 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(35))
+                .endDate(LocalDateTime.now().minusDays(5))
+                .createdAt(LocalDateTime.now().minusDays(35))
+                .build();
+        entityManager.persistAndFlush(challenge3);
+
         Mission mission = Mission.builder()
                 .missionCode(3L)
+                .challenge(challenge3)
                 .missionName("완료된 미션")
                 .missionContent("완료된 미션 내용")
                 .missionStatus(MissionStatus.COMPLETED)

--- a/src/test/java/com/be90z/domain/mission/repository/MissionRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/mission/repository/MissionRepositoryTest.java
@@ -1,0 +1,124 @@
+package com.be90z.domain.mission.repository;
+
+import com.be90z.domain.challenge.entity.Challenge;
+import com.be90z.domain.mission.entity.Mission;
+import com.be90z.domain.mission.entity.MissionStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@DisplayName("MissionRepository 테스트")
+class MissionRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Test
+    @DisplayName("미션 상태별 조회")
+    void findByMissionStatus() {
+        // given
+        Challenge challenge = Challenge.builder()
+                .challengeName("테스트 챌린지")
+                .challengeDescription("테스트 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().plusDays(25))
+                .createdAt(LocalDateTime.now().minusDays(5))
+                .build();
+        entityManager.persistAndFlush(challenge);
+
+        Mission activeMission = Mission.builder()
+                .missionCode(1L)
+                .challenge(challenge)
+                .missionName("활성 미션")
+                .missionContent("활성 미션 내용")
+                .missionStatus(MissionStatus.ACTIVE)
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(30))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Mission completedMission = Mission.builder()
+                .missionCode(2L)
+                .challenge(challenge)
+                .missionName("완료된 미션")
+                .missionContent("완료된 미션 내용")
+                .missionStatus(MissionStatus.COMPLETED)
+                .startDate(LocalDateTime.now().minusDays(30))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .createdAt(LocalDateTime.now().minusDays(30))
+                .build();
+
+        entityManager.persistAndFlush(activeMission);
+        entityManager.persistAndFlush(completedMission);
+
+        // when
+        List<Mission> activeMissions = missionRepository.findByMissionStatus(MissionStatus.ACTIVE);
+        List<Mission> completedMissions = missionRepository.findByMissionStatus(MissionStatus.COMPLETED);
+
+        // then
+        assertThat(activeMissions).hasSize(1);
+        assertThat(activeMissions.get(0).getMissionName()).isEqualTo("활성 미션");
+        
+        assertThat(completedMissions).hasSize(1);
+        assertThat(completedMissions.get(0).getMissionName()).isEqualTo("완료된 미션");
+    }
+
+    @Test
+    @DisplayName("현재 진행중인 미션 조회")
+    void findActiveMissions() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        
+        Challenge challenge2 = Challenge.builder()
+                .challengeName("테스트 챌린지 2")
+                .challengeDescription("테스트 챌린지 설명 2")
+                .startDate(now.minusDays(10))
+                .endDate(now.plusDays(10))
+                .createdAt(now.minusDays(10))
+                .build();
+        entityManager.persistAndFlush(challenge2);
+        
+        Mission currentMission = Mission.builder()
+                .missionCode(3L)
+                .challenge(challenge2)
+                .missionName("현재 진행중인 미션")
+                .missionContent("현재 진행중인 미션 내용")
+                .missionStatus(MissionStatus.ACTIVE)
+                .startDate(now.minusDays(1))
+                .endDate(now.plusDays(1))
+                .createdAt(now.minusDays(1))
+                .build();
+
+        Mission expiredMission = Mission.builder()
+                .missionCode(4L)
+                .challenge(challenge2)
+                .missionName("만료된 미션")
+                .missionContent("만료된 미션 내용")
+                .missionStatus(MissionStatus.ACTIVE)
+                .startDate(now.minusDays(10))
+                .endDate(now.minusDays(1))
+                .createdAt(now.minusDays(10))
+                .build();
+
+        entityManager.persistAndFlush(currentMission);
+        entityManager.persistAndFlush(expiredMission);
+
+        // when
+        List<Mission> activeMissions = missionRepository.findActiveMissions(now);
+
+        // then
+        assertThat(activeMissions).hasSize(1);
+        assertThat(activeMissions.get(0).getMissionName()).isEqualTo("현재 진행중인 미션");
+    }
+}

--- a/src/test/java/com/be90z/domain/raffle/entity/RaffleEntryTest.java
+++ b/src/test/java/com/be90z/domain/raffle/entity/RaffleEntryTest.java
@@ -1,5 +1,6 @@
 package com.be90z.domain.raffle.entity;
 
+import com.be90z.domain.challenge.entity.Challenge;
 import com.be90z.domain.mission.entity.MissionParticipation;
 import com.be90z.domain.mission.entity.Mission;
 import com.be90z.domain.mission.entity.MissionStatus;
@@ -31,8 +32,17 @@ class RaffleEntryTest {
                 .birth(1990)
                 .build();
 
+        Challenge challenge = Challenge.builder()
+                .challengeName("테스트 챌린지")
+                .challengeDescription("테스트 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().plusDays(25))
+                .createdAt(LocalDateTime.now().minusDays(5))
+                .build();
+
         Mission mission = Mission.builder()
                 .missionCode(1L)
+                .challenge(challenge)
                 .missionName("테스트 미션")
                 .missionContent("테스트 미션 내용")
                 .missionStatus(MissionStatus.ACTIVE)

--- a/src/test/java/com/be90z/domain/raffle/entity/RaffleWinnerTest.java
+++ b/src/test/java/com/be90z/domain/raffle/entity/RaffleWinnerTest.java
@@ -1,5 +1,6 @@
 package com.be90z.domain.raffle.entity;
 
+import com.be90z.domain.challenge.entity.Challenge;
 import com.be90z.domain.mission.entity.MissionParticipation;
 import com.be90z.domain.mission.entity.Mission;
 import com.be90z.domain.mission.entity.MissionStatus;
@@ -31,8 +32,17 @@ class RaffleWinnerTest {
                 .birth(1990)
                 .build();
 
+        Challenge challenge = Challenge.builder()
+                .challengeName("테스트 챌린지")
+                .challengeDescription("테스트 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().plusDays(25))
+                .createdAt(LocalDateTime.now().minusDays(5))
+                .build();
+
         Mission mission = Mission.builder()
                 .missionCode(1L)
+                .challenge(challenge)
                 .missionName("테스트 미션")
                 .missionContent("테스트 미션 내용")
                 .missionStatus(MissionStatus.ACTIVE)

--- a/src/test/java/com/be90z/domain/raffle/repository/RaffleEntryRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/raffle/repository/RaffleEntryRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.be90z.domain.raffle.repository;
 
+import com.be90z.domain.challenge.entity.Challenge;
 import com.be90z.domain.raffle.entity.RaffleEntry;
 import com.be90z.domain.mission.entity.Mission;
 import com.be90z.domain.mission.entity.MissionParticipation;
@@ -44,8 +45,18 @@ class RaffleEntryRepositoryTest {
                 .build();
         entityManager.persistAndFlush(user);
 
+        Challenge challenge = Challenge.builder()
+                .challengeName("래플 챌린지")
+                .challengeDescription("래플 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(35))
+                .endDate(LocalDateTime.now().minusDays(5))
+                .createdAt(LocalDateTime.now().minusDays(35))
+                .build();
+        entityManager.persistAndFlush(challenge);
+
         Mission mission = Mission.builder()
                 .missionCode(1L)
+                .challenge(challenge)
                 .missionName("래플 미션")
                 .missionContent("래플 미션 내용")
                 .missionStatus(MissionStatus.COMPLETED)
@@ -98,8 +109,18 @@ class RaffleEntryRepositoryTest {
                 .build();
         entityManager.persistAndFlush(user);
 
+        Challenge challenge2 = Challenge.builder()
+                .challengeName("래플 챌린지2")
+                .challengeDescription("래플 챌린지2 설명")
+                .startDate(LocalDateTime.now().minusDays(35))
+                .endDate(LocalDateTime.now().minusDays(5))
+                .createdAt(LocalDateTime.now().minusDays(35))
+                .build();
+        entityManager.persistAndFlush(challenge2);
+
         Mission mission = Mission.builder()
                 .missionCode(2L)
+                .challenge(challenge2)
                 .missionName("래플 미션2")
                 .missionContent("래플 미션2 내용")
                 .missionStatus(MissionStatus.COMPLETED)

--- a/src/test/java/com/be90z/domain/raffle/repository/RaffleWinnerRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/raffle/repository/RaffleWinnerRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.be90z.domain.raffle.repository;
 
+import com.be90z.domain.challenge.entity.Challenge;
 import com.be90z.domain.raffle.entity.RaffleEntry;
 import com.be90z.domain.raffle.entity.RaffleWinner;
 import com.be90z.domain.mission.entity.Mission;
@@ -45,8 +46,18 @@ class RaffleWinnerRepositoryTest {
                 .build();
         entityManager.persistAndFlush(user);
 
+        Challenge challenge = Challenge.builder()
+                .challengeName("당첨 챌린지")
+                .challengeDescription("당첨 챌린지 설명")
+                .startDate(LocalDateTime.now().minusDays(35))
+                .endDate(LocalDateTime.now().minusDays(5))
+                .createdAt(LocalDateTime.now().minusDays(35))
+                .build();
+        entityManager.persistAndFlush(challenge);
+
         Mission mission = Mission.builder()
                 .missionCode(1L)
+                .challenge(challenge)
                 .missionName("당첨 미션")
                 .missionContent("당첨 미션 내용")
                 .missionStatus(MissionStatus.COMPLETED)
@@ -117,8 +128,18 @@ class RaffleWinnerRepositoryTest {
                 .build();
         entityManager.persistAndFlush(user2);
 
+        Challenge challenge2 = Challenge.builder()
+                .challengeName("당첨 챌린지2")
+                .challengeDescription("당첨 챌린지2 설명")
+                .startDate(LocalDateTime.now().minusDays(35))
+                .endDate(LocalDateTime.now().minusDays(5))
+                .createdAt(LocalDateTime.now().minusDays(35))
+                .build();
+        entityManager.persistAndFlush(challenge2);
+
         Mission mission = Mission.builder()
                 .missionCode(2L)
+                .challenge(challenge2)
                 .missionName("당첨 미션2")
                 .missionContent("당첨 미션2 내용")
                 .missionStatus(MissionStatus.COMPLETED)

--- a/src/test/java/com/be90z/domain/user/entity/UserTest.java
+++ b/src/test/java/com/be90z/domain/user/entity/UserTest.java
@@ -1,0 +1,58 @@
+package com.be90z.domain.user.entity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+@DisplayName("User 엔티티 테스트")
+class UserTest {
+
+    @Test
+    @DisplayName("User 엔티티 생성 테스트")
+    void createUser() {
+        // given
+        String provider = "kakao";
+        String nickname = "테스트유저";
+        String email = "test@example.com";
+        UserAuthority auth = UserAuthority.USER;
+        LocalDateTime createdAt = LocalDateTime.now();
+        Gender gender = Gender.WOMAN;
+        int birth = 1990;
+
+        // when
+        User user = User.builder()
+                .provider(provider)
+                .nickname(nickname)
+                .email(email)
+                .auth(auth)
+                .createdAt(createdAt)
+                .gender(gender)
+                .birth(birth)
+                .build();
+
+        // then
+        assertThat(user.getProvider()).isEqualTo(provider);
+        assertThat(user.getNickname()).isEqualTo(nickname);
+        assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getAuth()).isEqualTo(auth);
+        assertThat(user.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(user.getGender()).isEqualTo(gender);
+        assertThat(user.getBirth()).isEqualTo(birth);
+    }
+
+    @Test
+    @DisplayName("User 엔티티 필수 필드 검증")
+    void validateRequiredFields() {
+        // given & when & then
+        assertThatThrownBy(() -> {
+            User.builder()
+                    .nickname("테스트유저")
+                    .email("test@example.com")
+                    // provider 누락
+                    .build();
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Provider cannot be null");
+    }
+}

--- a/src/test/java/com/be90z/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/be90z/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.be90z.domain.user.repository;
+
+import com.be90z.domain.user.entity.User;
+import com.be90z.domain.user.entity.UserAuthority;
+import com.be90z.domain.user.entity.Gender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@DisplayName("UserRepository 테스트")
+class UserRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("이메일로 사용자 조회")
+    void findByEmail() {
+        // given
+        User user = User.builder()
+                .provider("kakao")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .gender(Gender.WOMAN)
+                .birth(1990)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        // when
+        Optional<User> found = userRepository.findByEmail("test@example.com");
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getNickname()).isEqualTo("테스트유저");
+    }
+
+    @Test
+    @DisplayName("provider와 이메일로 사용자 조회")
+    void findByProviderAndEmail() {
+        // given
+        User user = User.builder()
+                .provider("kakao")
+                .nickname("카카오유저")
+                .email("kakao@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .gender(Gender.MAN)
+                .birth(1985)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        // when
+        Optional<User> found = userRepository.findByProviderAndEmail("kakao", "kakao@example.com");
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getNickname()).isEqualTo("카카오유저");
+    }
+
+    @Test
+    @DisplayName("이메일 존재 여부 확인")
+    void existsByEmail() {
+        // given
+        User user = User.builder()
+                .provider("kakao")
+                .nickname("존재하는유저")
+                .email("exists@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .gender(Gender.WOMAN)
+                .birth(1992)
+                .build();
+        entityManager.persistAndFlush(user);
+
+        // when & then
+        assertThat(userRepository.existsByEmail("exists@example.com")).isTrue();
+        assertThat(userRepository.existsByEmail("notexists@example.com")).isFalse();
+    }
+}


### PR DESCRIPTION
🌟개요
---
기존 도메인의 테스트 커버리지를 개선하고, 엔티티 간 의존성을 정리하여 테스트 안정성을 향상시킵니다.

🌐연결된 Issues
---
N/A (테스트 품질 개선)

📋작업사항
---
### Challenge 도메인 테스트
- `ChallengeTest`: Challenge 엔티티 단위 테스트
- `ChallengeRepositoryTest`: Challenge Repository 테스트

### Mission 도메인 테스트 개선
- `MissionTest`: Mission 엔티티 테스트 개선
- `MissionRepositoryTest`: Mission Repository 쿼리 테스트
- `MissionParticipationRepositoryTest`: 참가 정보 Repository 테스트

### User 도메인 테스트 추가
- `UserTest`: User 엔티티 테스트
- `UserRepositoryTest`: User Repository 테스트

### 테스트 의존성 개선
- Mission 엔티티 테스트에서 Challenge 필수 필드 추가
- 엔티티 간 연관관계 테스트 케이스 보강
- 테스트 데이터 생성 로직 개선

✏️작성한 이슈 외 작업사항
---
- @DataJpaTest를 활용한 Repository 계층 테스트
- AssertJ를 활용한 가독성 높은 테스트 검증
- 테스트 픽스처(Fixture) 패턴 적용
- 엔티티 생성자 및 빌더 패턴 테스트

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?

🤖 Generated with [Claude Code](https://claude.ai/code)