### PR TITLE
Feat/recipe tag ai

### DIFF
--- a/src/main/java/com/be90z/domain/recipe/dto/RecipeAiResDTO.java
+++ b/src/main/java/com/be90z/domain/recipe/dto/RecipeAiResDTO.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Data
 public class RecipeAiResDTO {
     private String recipeName;
+    private List<String> suggestedIngredients; // AI가 추출한 15개 재료 리스트
     @Lob
     private String recipeContent;
     private Integer recipeCalories;

--- a/src/main/java/com/be90z/domain/recipe/dto/RecipeResDTO.java
+++ b/src/main/java/com/be90z/domain/recipe/dto/RecipeResDTO.java
@@ -1,6 +1,7 @@
 package com.be90z.domain.recipe.dto;
 
 import com.be90z.domain.recipe.entity.RecipePeople;
+import com.be90z.domain.recipeTag.dto.RecipeTagResDTO;
 import jakarta.persistence.Lob;
 import lombok.Data;
 
@@ -11,6 +12,9 @@ import java.util.List;
 public class RecipeResDTO {
     private Long recipeCode;
     private String recipeName;
+    private List<RecipeTagResDTO> recipeTagList;
+
+
     @Lob
     private String recipeContent;
     private Integer recipeCalories;
@@ -33,5 +37,16 @@ public class RecipeResDTO {
         private Long imgCode;
         private String imgName;
         private String imgS3url;
+    }
+
+    @Data
+    public static class RecipeTagResDTO {
+        private Long recipeTagCode;
+        private String tagName;
+
+        public RecipeTagResDTO(Long recipeTagCode, String tagName) {
+            this.recipeTagCode = recipeTagCode;
+            this.tagName = tagName;
+        }
     }
 }

--- a/src/main/java/com/be90z/domain/recipe/dto/RecipeUpdateDTO.java
+++ b/src/main/java/com/be90z/domain/recipe/dto/RecipeUpdateDTO.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Data
 public class RecipeUpdateDTO {
     private String recipeName;
+    private List<String> selectedTags; // 사용자가 선택한 태그
     @Lob
     private String recipeContent;
     private Integer recipeCalories;

--- a/src/main/java/com/be90z/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/be90z/domain/recipe/service/RecipeService.java
@@ -9,6 +9,8 @@ import com.be90z.domain.recipe.entity.ImageCategory;
 import com.be90z.domain.recipe.entity.Ingredients;
 import com.be90z.domain.recipe.entity.Recipe;
 import com.be90z.domain.recipe.repository.RecipeRepository;
+import com.be90z.domain.recipeTag.dto.RecipeTagResDTO;
+import com.be90z.domain.recipeTag.service.RecipeTagService;
 import com.be90z.domain.tag.service.TagService;
 import com.be90z.domain.user.repository.UserRepository;
 import com.be90z.external.gemini.service.GeminiResParser;
@@ -33,6 +35,7 @@ public class RecipeService {
     private final UserRepository userRepository;
     private final TagService tagService;
     private final GeminiResParser geminiResParser;
+    private final RecipeTagService recipeTagService;
 
     //   AI로 레시피 분석
     @Transactional
@@ -213,6 +216,7 @@ public class RecipeService {
              throw new RuntimeException("레시피 삭제 권한이 없습니다.");
          } */
 
+        recipeTagService.deleteRecipeTags(recipeCode);
         imageService.deleteAllImagesByRecipe(recipeCode);
         recipeRepository.delete(recipe);
     }
@@ -264,6 +268,15 @@ public class RecipeService {
                 .collect(Collectors.toList());
 
         recipeResDTO.setImagesList(imagesList);
+
+        // 🔥 레시피 태그 정보 추가
+        List<RecipeTagResDTO> recipeTags = recipeTagService.getRecipeTags(recipe.getRecipeCode());
+        List<RecipeResDTO.RecipeTagResDTO> recipeTagList = recipeTags.stream()
+                .map(tag -> new RecipeResDTO.RecipeTagResDTO(tag.getRecipeTagCode(), tag.getRecipeTagName()))
+                .collect(Collectors.toList());
+
+        recipeResDTO.setRecipeTagList(recipeTagList);
+
         return recipeResDTO;
     }
 }

--- a/src/main/java/com/be90z/domain/recipeTag/controller/RecipeTagController.java
+++ b/src/main/java/com/be90z/domain/recipeTag/controller/RecipeTagController.java
@@ -1,0 +1,66 @@
+package com.be90z.domain.recipeTag.controller;
+
+import com.be90z.domain.recipeTag.dto.RecipeIngredientAIResDTO;
+import com.be90z.domain.recipeTag.dto.RecipeTagResDTO;
+import com.be90z.domain.recipeTag.dto.RecipeTagSelectReqDTO;
+import com.be90z.domain.recipeTag.service.RecipeTagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "recipe-tag", description = "레시피 태그 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recipe-tag")
+public class RecipeTagController {
+
+    private final RecipeTagService recipeTagService;
+
+    @PostMapping("/ai-recipeTae")
+    @Operation(summary = "AI 재료 추출", description = "레시피 내용을 분석하여 관련 재료 15개를 추출합니다")
+    public ResponseEntity<RecipeIngredientAIResDTO> extractIngredients(
+            @RequestParam String recipeName,
+            @RequestParam String recipeContent) {
+
+        RecipeIngredientAIResDTO response = recipeTagService.extractIngredientsFromRecipe(recipeName, recipeContent);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{recipeCode}/select")
+    @Operation(summary = "메인 재료 선택", description = "추출된 재료 중 최대 3개를 선택하여 레시피 태그로 저장합니다")
+    public ResponseEntity<List<RecipeTagResDTO>> selectAndSaveTags(
+            @PathVariable Long recipeCode,
+            @RequestBody RecipeTagSelectReqDTO selectionReqDTO) {
+
+        List<RecipeTagResDTO> savedTags = recipeTagService.saveSelectedTags(recipeCode, selectionReqDTO);
+        return ResponseEntity.ok(savedTags);
+    }
+
+    @GetMapping("/{recipeCode}")
+    @Operation(summary = "레시피 태그 조회", description = "특정 레시피의 모든 태그를 조회합니다")
+    public ResponseEntity<List<RecipeTagResDTO>> getRecipeTags(@PathVariable Long recipeCode) {
+        List<RecipeTagResDTO> recipeTags = recipeTagService.getRecipeTags(recipeCode);
+        return ResponseEntity.ok(recipeTags);
+    }
+
+    @PutMapping("/{recipeCode}")
+    @Operation(summary = "레시피 태그 수정", description = "레시피 수정 시 태그를 업데이트합니다")
+    public ResponseEntity<List<RecipeTagResDTO>> updateRecipeTags(
+            @PathVariable Long recipeCode,
+            @RequestBody RecipeTagSelectReqDTO selectionReqDTO) {
+
+        List<RecipeTagResDTO> updatedTags = recipeTagService.updateRecipeTags(recipeCode, selectionReqDTO);
+        return ResponseEntity.ok(updatedTags);
+    }
+
+    @DeleteMapping("/{recipeCode}")
+    @Operation(summary = "레시피 태그 삭제", description = "특정 레시피의 모든 태그를 삭제합니다")
+    public ResponseEntity<String> deleteRecipeTags(@PathVariable Long recipeCode) {
+        recipeTagService.deleteRecipeTags(recipeCode);
+        return ResponseEntity.ok("레시피 태그가 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/be90z/domain/recipeTag/dto/RecipeIngredientAIResDTO.java
+++ b/src/main/java/com/be90z/domain/recipeTag/dto/RecipeIngredientAIResDTO.java
@@ -1,0 +1,22 @@
+package com.be90z.domain.recipeTag.dto;
+
+import lombok.Data;
+import java.util.List;
+
+/**
+ * 레시피 태그 관련 DTO 클래스들
+ * 이 파일에는 3개의 DTO 클래스가 포함되어 있습니다:
+ * 1. RecipeIngredientExtractionResDTO - AI 재료 추출 응답
+ * 2. RecipeTagSelectionReqDTO - 사용자 재료 선택 요청
+ * 3. RecipeTagResDTO - 레시피 태그 응답
+ */
+
+// Ai가 추출한 재료 15개 리스트 응답 DTO
+@Data
+public class RecipeIngredientAIResDTO {
+    private List<String> IngredientWithAI;
+
+    public RecipeIngredientAIResDTO(List<String> IngredientWithAI) {
+        this.IngredientWithAI = IngredientWithAI;
+    }
+}

--- a/src/main/java/com/be90z/domain/recipeTag/dto/RecipeTagResDTO.java
+++ b/src/main/java/com/be90z/domain/recipeTag/dto/RecipeTagResDTO.java
@@ -1,0 +1,15 @@
+package com.be90z.domain.recipeTag.dto;
+
+import lombok.Data;
+
+// 레시피 태그 응답 DTO
+@Data
+public class RecipeTagResDTO {
+    private Long recipeTagCode;
+    private String recipeTagName;
+
+    public RecipeTagResDTO(Long recipeTagCode, String recipeTagName) {
+        this.recipeTagCode = recipeTagCode;
+        this.recipeTagName = recipeTagName;
+    }
+}

--- a/src/main/java/com/be90z/domain/recipeTag/dto/RecipeTagSelectReqDTO.java
+++ b/src/main/java/com/be90z/domain/recipeTag/dto/RecipeTagSelectReqDTO.java
@@ -1,0 +1,17 @@
+package com.be90z.domain.recipeTag.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+// 사용자가 선택한 재료 3개 요청 DTO
+@Data
+public class RecipeTagSelectReqDTO {
+    private List<String> selectedRecipeTags;
+
+    public boolean isValid() {
+        return selectedRecipeTags != null &&
+                !selectedRecipeTags.isEmpty() &&
+                selectedRecipeTags.size() <= 3;
+    }
+}

--- a/src/main/java/com/be90z/domain/recipeTag/entity/RecipeTag.java
+++ b/src/main/java/com/be90z/domain/recipeTag/entity/RecipeTag.java
@@ -1,0 +1,34 @@
+package com.be90z.domain.recipeTag.entity;
+
+import com.be90z.domain.recipe.entity.Recipe;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name="recipe_tag")
+public class RecipeTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_tag_code", nullable = false)
+    private Long recipeTagCode;
+
+    @Column(name = "recipe_tag_name")
+    private String recipeTagName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_code")
+    private Recipe recipe;
+
+    public RecipeTag(String recipeTagName, Recipe recipe) {
+        this.recipeTagName = recipeTagName;
+        this.recipe = recipe;
+    }
+
+    public void updateTagName(String recipeTagName) {
+        this.recipeTagName = recipeTagName;
+    }
+}

--- a/src/main/java/com/be90z/domain/recipeTag/repository/RecipeTagRepository.java
+++ b/src/main/java/com/be90z/domain/recipeTag/repository/RecipeTagRepository.java
@@ -1,0 +1,13 @@
+package com.be90z.domain.recipeTag.repository;
+
+import com.be90z.domain.recipeTag.entity.RecipeTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
+    void deleteByRecipeTagCode(Long recipeTagCode);
+    List<RecipeTag> findByRecipe_RecipeCode(Long recipeCode);
+}

--- a/src/main/java/com/be90z/domain/recipeTag/service/RecipeTagService.java
+++ b/src/main/java/com/be90z/domain/recipeTag/service/RecipeTagService.java
@@ -1,0 +1,104 @@
+package com.be90z.domain.recipeTag.service;
+
+import com.be90z.domain.recipe.entity.Recipe;
+import com.be90z.domain.recipe.repository.RecipeRepository;
+import com.be90z.domain.recipeTag.dto.RecipeIngredientAIResDTO;
+import com.be90z.domain.recipeTag.dto.RecipeTagResDTO;
+import com.be90z.domain.recipeTag.dto.RecipeTagSelectReqDTO;
+import com.be90z.domain.recipeTag.entity.RecipeTag;
+import com.be90z.domain.recipeTag.repository.RecipeTagRepository;
+import com.be90z.external.gemini.service.GeminiResParser;
+import com.be90z.external.gemini.service.GeminiService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecipeTagService {
+
+    private final RecipeTagRepository recipeTagRepository;
+    private final RecipeRepository recipeRepository;
+    private final GeminiService geminiService;
+    private final GeminiResParser geminiResParser;
+    private final ObjectMapper objectMapper;
+
+//    AI 를 통한 관련 재료 15개 추출
+    @Transactional(readOnly = true)
+    public RecipeIngredientAIResDTO extractIngredientsFromRecipe(String recipeName, String recipeContent) {
+        try {
+            log.info("AI 재료 추출 요청 - 레시피명: {}", recipeName);
+            String geminiResponse = geminiService.extractIngredientsForTags(recipeName, recipeContent);
+
+//            Json 응답에서 재료 리스트 추출
+            List<String> extractedIngredients = geminiResParser.parseReponse(geminiResponse, new TypeReference<List<String>>() {});
+
+            log.info("AI 재료 추출 완료 - 추출된 재료 개수: {}", extractedIngredients.size());
+            return new RecipeIngredientAIResDTO(extractedIngredients);
+
+        } catch (Exception e) {
+            log.error("AI 재료 추출 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("재료 추출에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    // 선택된 재료 3개를 recipe_tag에 저장
+    @Transactional
+    public List<RecipeTagResDTO> saveSelectedTags(Long recipeCode, RecipeTagSelectReqDTO selectionReqDTO) {
+        if (!selectionReqDTO.isValid()) {
+            throw new IllegalArgumentException("1개 이상 3개 이하의 재료를 선택해야 합니다.");
+        }
+        Recipe recipe = recipeRepository.findById(recipeCode)
+                .orElseThrow(() -> new RuntimeException("레시피를 찾을 수 없습니다: " + recipeCode));
+
+        // 기존 태그들 삭제
+        recipeTagRepository.deleteByRecipeTagCode(recipeCode);
+
+        // 새로운 태그들 저장
+        List<RecipeTag> savedTags = selectionReqDTO.getSelectedRecipeTags().stream()
+                .map(ingredient -> {
+                    RecipeTag recipeTag = new RecipeTag(ingredient, recipe);
+                    return recipeTagRepository.save(recipeTag);
+                })
+                .collect(Collectors.toList());
+
+        log.info("레시피 태그 저장 완료 - 레시피코드: {}, 태그 개수: {}", recipeCode, savedTags.size());
+
+        return savedTags.stream()
+                .map(tag -> new RecipeTagResDTO(tag.getRecipeTagCode(), tag.getRecipeTagName()))
+                .collect(Collectors.toList());
+    }
+
+    // 특정 레시피의 태그 조회
+    @Transactional(readOnly = true)
+    public List<RecipeTagResDTO> getRecipeTags(Long recipeCode) {
+        List<RecipeTag> recipeTags = recipeTagRepository.findByRecipe_RecipeCode(recipeCode);
+
+        return recipeTags.stream()
+                .map(tag -> new RecipeTagResDTO(tag.getRecipeTagCode(), tag.getRecipeTagName()))
+                .collect(Collectors.toList());
+    }
+
+    // 레시피 수정 시 태그 업데이트
+    @Transactional
+    public List<RecipeTagResDTO> updateRecipeTags(Long recipeCode, RecipeTagSelectReqDTO selectionReqDTO) {
+        log.info("레시피 태그 수정 요청 - 레시피코드: {}", recipeCode);
+
+        // 기존 저장 로직과 동일하게 처리 (삭제 후 재생성)
+        return saveSelectedTags(recipeCode, selectionReqDTO);
+    }
+
+    // 레시피 삭제 시 관련 태그들도 삭제
+    @Transactional
+    public void deleteRecipeTags(Long recipeCode) {
+        recipeTagRepository.deleteById(recipeCode);
+        log.info("레시피 태그 삭제 완료 - 레시피코드: {}", recipeCode);
+    }
+}

--- a/src/main/java/com/be90z/domain/user/dto/request/LoginReqDTO.java
+++ b/src/main/java/com/be90z/domain/user/dto/request/LoginReqDTO.java
@@ -1,4 +1,0 @@
-package com.be90z.domain.user.dto.request;
-
-public class LoginReqDTO {
-}

--- a/src/main/java/com/be90z/domain/user/dto/request/ProfileUpdateReqDTO.java
+++ b/src/main/java/com/be90z/domain/user/dto/request/ProfileUpdateReqDTO.java
@@ -1,4 +1,0 @@
-package com.be90z.domain.user.dto.request;
-
-public class ProfileUpdateReqDTO {
-}

--- a/src/main/java/com/be90z/domain/user/dto/response/KakaoUserResDTO.java
+++ b/src/main/java/com/be90z/domain/user/dto/response/KakaoUserResDTO.java
@@ -9,31 +9,4 @@ public class KakaoUserResDTO {
     private String id;
     private String nickname;
     private String email;
-    private String gender;
-    private String birthday;
-
-//    카카오 성별 정보 enum 변환
-    public String getConvertedGender() {
-        if ("female".equals(this.gender)) {
-            return "WOMAN";
-        } else if ("male".equals(this.gender)) {
-            return "MAN";
-        }
-        return "MAN";
-    }
-
-//    생일 정보 출생년도만 추출
-    public Integer getBirthYear() {
-        if (birthday == null || birthday.isEmpty()) {
-            return 2000; // 기본값: 정보가 없으면 2000년으로 설정
-        }
-
-        try {
-            // 첫 4글자를 숫자로 변환 (년도 부분)
-            return Integer.parseInt(birthday.substring(0, 4));
-        } catch (Exception e) {
-            // 변환에 실패하면 기본값 반환
-            return 2000;
-        }
-    }
 }

--- a/src/main/java/com/be90z/domain/user/entity/Auth.java
+++ b/src/main/java/com/be90z/domain/user/entity/Auth.java
@@ -1,5 +1,0 @@
-package com.be90z.domain.user.entity;
-
-public enum Auth {
-    USER, ADMIN
-}

--- a/src/main/java/com/be90z/domain/user/service/AuthUserService.java
+++ b/src/main/java/com/be90z/domain/user/service/AuthUserService.java
@@ -2,9 +2,8 @@ package com.be90z.domain.user.service;
 
 import com.be90z.domain.user.dto.response.KakaoUserResDTO;
 import com.be90z.domain.user.dto.response.LoginResDTO;
-import com.be90z.domain.user.entity.Auth;
-import com.be90z.domain.user.entity.Gender;
 import com.be90z.domain.user.entity.User;
+import com.be90z.domain.user.entity.UserAuthority;
 import com.be90z.domain.user.repository.UserRepository;
 import com.be90z.global.config.RestTemplateConfig;
 import com.be90z.global.util.JwtUtil;
@@ -15,6 +14,7 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -119,11 +119,9 @@ public class AuthUserService {
         // kakao_account에서 개인정보 추출
         Map<String, Object> kakaoAccount = (Map<String, Object>) responseData.get("kakao_account");
         String email = null;
-        String gender = null;
 
         if (kakaoAccount != null) {
             email = (String) kakaoAccount.get("email");
-            gender = (String) kakaoAccount.get("gender");
         }
 
         // kakaoUserResDTO 객체 생성 후 반환
@@ -131,7 +129,6 @@ public class AuthUserService {
                 .id(id)
                 .nickname(nickname)
                 .email(email)
-                .gender(gender)
                 .build();
     }
 
@@ -189,9 +186,7 @@ public class AuthUserService {
                             .provider(kakaoId)
                             .nickname(kakaoUserResDTO.getNickname())
                             .email(kakaoUserResDTO.getEmail())
-                            .gender(Gender.valueOf(convertGender(kakaoUserResDTO.getGender())))
-                            .birth(kakaoUserResDTO.getBirthYear())
-//                            .auth(Auth.USER)  // 기본값
+                            .auth(UserAuthority.USER)  // 기본값
                             .createdAt(LocalDateTime.now())
                             .build();
 
@@ -199,17 +194,7 @@ public class AuthUserService {
                 });
     }
 
-    //    카카오 성별 정보를 우리 시스템 형식으로 변환
-    private String convertGender(String kakaoGender) {
-        if ("female".equals(kakaoGender)) {
-            return "WOMAN";
-        } else if ("male".equals(kakaoGender)) {
-            return "MAN";
-        }
-        return "MAN"; // 기본값
-    }
-
-//    토큰 유효성 검증 메서드
+    //    토큰 유효성 검증 메서드
     public boolean validateToken(String token) {
         try {
             return jwtUtil.validateToken(token);

--- a/src/main/java/com/be90z/external/gemini/prompt/GeminiIngredientPrompt.java
+++ b/src/main/java/com/be90z/external/gemini/prompt/GeminiIngredientPrompt.java
@@ -1,0 +1,82 @@
+package com.be90z.external.gemini.prompt;
+
+import org.springframework.stereotype.Component;
+
+/* Gemini AI 재료 추출용 프롬프트 관리 클래스 */
+@Component
+public class GeminiIngredientPrompt {
+
+    public String createIngredientExtractionPrompt(String recipeName, String recipeContent) {
+        return String.format(INGREDIENT_EXTRACTION_TEMPLATE, sanitizeInput(recipeName), sanitizeInput(recipeContent));
+    }
+
+    private static final String INGREDIENT_EXTRACTION_TEMPLATE = """
+            당신은 요리 전문가입니다. 주어진 레시피를 분석하여 이 레시피와 관련된 주요 재료 15개를 추출해주세요.
+            
+            === 사용자 입력 ===
+            제목: %s
+            내용: %s
+            
+            === 추출 규칙 ===
+            1. 레시피에 직접 언급된 재료들을 우선적으로 포함
+            2. 해당 요리와 함께 자주 사용되는 대표적인 재료들 포함
+            3. 기본 조미료(소금, 후추, 설탕, 식용유 등)도 포함
+            4. 대체 가능한 재료들도 포함 (예: 올리브오일 대신 식용유)
+            5. 최대 15개의 재료명만 추출
+            6. 재료명은 간단하고 명확하게 (예: "계란", "양파", "마늘", "간장")
+            7. 브랜드명이나 구체적인 제품명은 제외 (예: "○○브랜드 간장" → "간장")
+            
+            === 응답 형식 ===
+            반드시 아래와 같은 JSON 배열 형식으로만 응답하세요:
+            - 백틱(`) 사용 금지
+            - ```json 마크다운 코드 블록 절대 금지
+            - ``` 감싸기 절대 금지
+            - 오직 [ 로 시작해서 ] 로 끝나는 순수한 JSON 배열만
+            - 추가 설명이나 텍스트 금지
+            - 정확히 15개의 재료명만 포함
+            
+            올바른 응답 예시:
+            ["계란", "크래미", "올리브오일", "소금", "후추", "양파", "마늘", "대파", "당근", "버터", "식용유", "참기름", "간장", "설탕", "밀가루"]
+            
+            잘못된 응답 (절대 금지):
+            ```json
+            ["계란", "크래미"]
+            ```
+            
+            또는
+            
+            다음은 추출된 재료입니다:
+            ["계란", "크래미"]
+            
+            === 주의사항 ===
+            - 응답은 반드시 [ 로 시작해서 ] 로 끝나는 순수한 JSON 배열만 제공
+            - 다른 어떤 텍스트나 설명도 포함하지 말 것
+            - 정확히 15개의 재료만 포함할 것
+            """;
+
+    // 사용자 입력 sanitization
+    private String sanitizeInput(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            return "(내용 없음)";
+        }
+        return input.trim()
+                .replace("\"", "'")           // 큰따옴표를 작은따옴표로
+                .replace("\n", " ")          // 줄바꿈을 공백으로
+                .replace("\r", " ")          // 캐리지 리턴을 공백으로
+                .replaceAll("\\s+", " ");    // 연속된 공백을 하나로
+    }
+
+    // 프롬프트 유효성 검사
+    public boolean isValidInput(String recipeName, String recipeContent) {
+        // 내용이 너무 짧으면 안됨
+        if (recipeContent == null || recipeContent.trim().length() < 10) {
+            return false;
+        }
+
+        // 내용이 너무 길면 안됨 (Gemini API 제한 고려)
+        if (recipeContent.length() > 3000) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/be90z/external/gemini/service/GeminiResParser.java
+++ b/src/main/java/com/be90z/external/gemini/service/GeminiResParser.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 // Gemini 응답 파싱 처리 클래스
 
@@ -14,11 +15,24 @@ public class GeminiResParser {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+//    레시피 작성 파싱
     public <T> T parseReponse(String geminiResponse, Class<T> targetClass) {
         try {
             String cleanedJson = cleanMarkdownFromJson(geminiResponse);
             log.debug("정리된 Json: {}", cleanedJson);
             return objectMapper.readValue(cleanedJson, targetClass);
+        } catch (JsonProcessingException e) {
+            log.error("Gemini 응답 파싱 실패: {}", geminiResponse.substring(0, Math.min(200, geminiResponse.length())));
+            throw new RuntimeException("Gemini 응답을 파싱할 수 없습니다: " + e.getMessage(), e);
+        }
+    }
+
+//    재료 추출 파싱
+    public <T> T parseReponse(String geminiResponse, TypeReference<T> typeReference) {
+        try {
+            String cleanedJson = cleanMarkdownFromJson(geminiResponse);
+            log.debug("정리된 Json: {}", cleanedJson);
+            return objectMapper.readValue(cleanedJson, typeReference);
         } catch (JsonProcessingException e) {
             log.error("Gemini 응답 파싱 실패: {}", geminiResponse.substring(0, Math.min(200, geminiResponse.length())));
             throw new RuntimeException("Gemini 응답을 파싱할 수 없습니다: " + e.getMessage(), e);
@@ -48,7 +62,8 @@ public class GeminiResParser {
         cleaned = cleaned.trim();
 
 //        Json 형식 기본 검증
-        if (!cleaned.startsWith("{") || !cleaned.endsWith("}")) {
+        if ((!cleaned.startsWith("{") || !cleaned.endsWith("}")) &&
+                (!cleaned.startsWith("[") || !cleaned.endsWith("]"))) {
             throw new JsonParsingException("올바르지 않은 Json 형식입니다.: " + cleaned);
         }
         return cleaned;


### PR DESCRIPTION
🌟개요
---
AI 기반 레시피 메인 재료 추출 및 태그 기능을 구현했습니다. 사용자가 작성한 레시피를 AI가 분석하여 관련 재료 15개를 추출하고, 사용자가 최대 3개를 선택하여 레시피 태그로 저장할 수 있는 기능입니다.

🌐연결된 Issues
---
Closes #24 

📋작업사항
---
### 🏗️ 새로운 도메인 추가 - RecipeTag
- **Entity**: `RecipeTag` - 레시피와 N:1 관계의 태그 엔티티 생성
- **Repository**: `RecipeTagRepository` - 레시피 태그 데이터 처리를 위한 JPA 레포지토리
- **Service**: `RecipeTagService` - AI 재료 추출, 태그 저장/수정/삭제 비즈니스 로직
- **Controller**: `RecipeTagController` - 태그 관련 REST API 엔드포인트
- **DTO**: 
 - `RecipeIngredientAIResDTO` - AI 재료 추출 15개 응답
 - `RecipeTagSelectReqDTO` - 사용자 재료 3개 선택 요청  
 - `RecipeTagResDTO` - 레시피 태그 응답

### 🤖 AI 재료 추출 기능
- **Prompt**: `GeminiIngredientPrompt` - 재료 추출 전용 프롬프트 관리 클래스
- **Service 확장**: `GeminiService.extractIngredientsForTags()` - 태그용 재료 추출 메서드 추가
- **Parser 확장**: `GeminiResParser.parseResponse()` - TypeReference 지원 메서드 추가

### 🔄 기존 기능 확장
- **RecipeService**: 태그 정보 포함 조회, 레시피 삭제 시 태그 연동 삭제
- **RecipeAiResDTO**: `suggestedIngredients` 필드 추가
- **RecipeResDTO**: `recipeTagList` 필드 추가  
- **RecipeUpdateDTO**: `selectedTags` 필드 추가

### 🛠️ API 엔드포인트
- `POST /api/v1/recipe-tag/extract` - AI 재료 15개 추출
- `POST /api/v1/recipe-tag/{recipeCode}/select` - 선택한 재료 3개 태그 저장
- `GET /api/v1/recipe-tag/{recipeCode}` - 레시피 태그 조회
- `PUT /api/v1/recipe-tag/{recipeCode}` - 레시피 태그 수정
- `DELETE /api/v1/recipe-tag/{recipeCode}` - 레시피 태그 삭제

✏️작성한 이슈 외 작업사항
---
### 🧹 코드 정리 작업
- **LoginReqDTO** 클래스 삭제 (미사용)
- **ProfileUpdateReqDTO** 클래스 삭제 (미사용)
- **Auth** 클래스 삭제 (UserAuthority와 중복)
- **AuthUserService** 불필요한 필드 제거
- **KakaoUserResDTO** 불필요한 필터 응답 제거

### 🔧 기술적 개선사항
- TypeReference를 활용한 Generic 타입 파싱 지원
- 트랜잭션 관리를 통한 데이터 일관성 보장
- 외래키 제약조건을 활용한 데이터 무결성 확보
- 최대한 기존 코드 수정 없이 새로운 기능 확장

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
