### PR TITLE
chore/recipe-ai: AI 레시피 분석 json 파싱 에러 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 //    s3
     implementation 'software.amazon.awssdk:s3:2.32.9'
 
+//    retry
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
 //    lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -65,6 +68,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.batch:spring-batch-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/be90z/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/be90z/domain/recipe/controller/RecipeController.java
@@ -11,15 +11,18 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Tag(name = "recipe", description = "레시피 API")
 @RestController
 @RequiredArgsConstructor
@@ -29,12 +32,22 @@ public class RecipeController {
     private final RecipeService recipeService;
     private final ObjectMapper objectMapper;
 
+//    @PostMapping("/ai")
+//    @Operation(summary = " AI 레시피 분석", description = "제목과 내용을 AI로 분석하여 레시피 상세 내용을 생성합니다")
+//    public ResponseEntity<RecipeAiResDTO> createRecipeWithAi(
+//            @RequestBody RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
+//        RecipeAiResDTO recipeAiResDTO = recipeService.createRecipeWithAi(recipeCreateFreeDTO);
+//        return ResponseEntity.ok(recipeAiResDTO);
+//    }
+
     @PostMapping("/ai")
-    @Operation(summary = " AI 레시피 분석", description = "제목과 내용을 AI로 분석하여 레시피 상세 내용을 생성합니다")
-    public ResponseEntity<RecipeAiResDTO> createRecipeWithAi(
+    @Operation(summary = "AI 레시피 분석 - 비동기", description = "제목과 내용을 AI로 분석하여 레시피 상세 내용을 생성합니다.")
+    public Mono<ResponseEntity<RecipeAiResDTO>> createRecipeWithAiAsync(
             @RequestBody RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
-        RecipeAiResDTO recipeAiResDTO = recipeService.createRecipeWithAi(recipeCreateFreeDTO);
-        return ResponseEntity.ok(recipeAiResDTO);
+        return recipeService.createRecipeWithAiAsync(recipeCreateFreeDTO)
+                .map(ResponseEntity::ok)
+                .doOnSuccess(response -> log.info("비동기 AI 레시피 분석 완료"))
+                .doOnError(error -> log.error("비동기 AI 레시피 분석 실패: ", error.getMessage()));
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/be90z/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/be90z/domain/recipe/service/RecipeService.java
@@ -15,7 +15,6 @@ import com.be90z.domain.tag.service.TagService;
 import com.be90z.domain.user.repository.UserRepository;
 import com.be90z.external.gemini.service.GeminiResParser;
 import com.be90z.external.gemini.service.GeminiService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,12 +44,12 @@ public class RecipeService {
 //                recipeCreateFreeDTO.getRecipeName(),
 //                recipeCreateFreeDTO.getRecipeContent()
 //        );
-//        return geminiResParser.parseReponse(geminiResJson, RecipeAiResDTO.class);
+//        return geminiResParser.parseResponse(geminiResJson, RecipeAiResDTO.class);
 //    }
 
-//    레시피 분석 비동기로
+    //    레시피 분석 비동기로
     @Transactional
-    public Mono<RecipeAiResDTO> createRecipeWithAiAsync (RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
+    public Mono<RecipeAiResDTO> createRecipeWithAiAsync(RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
         return geminiService.analyzeRecipeAsync(
                 recipeCreateFreeDTO.getRecipeName(),
                 recipeCreateFreeDTO.getRecipeContent()
@@ -74,9 +73,9 @@ public class RecipeService {
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId));
 
 //        요리방식 유효성 검증
-        if(recipeAiResDTO.getRecipeCookMethod() != null &&
-        !recipeAiResDTO.getRecipeCookMethod().trim().isEmpty() &&
-        !tagService.isValidTag(recipeAiResDTO.getRecipeCookMethod())) {
+        if (recipeAiResDTO.getRecipeCookMethod() != null &&
+                !recipeAiResDTO.getRecipeCookMethod().trim().isEmpty() &&
+                !tagService.isValidTag(recipeAiResDTO.getRecipeCookMethod())) {
             throw new RuntimeException("유효하지 않는 요리방식입니다.: " + recipeAiResDTO.getRecipeCookMethod());
         }
 
@@ -146,7 +145,7 @@ public class RecipeService {
      } */
 
         //        요리방식 유효성 검증
-        if(recipeUpdateDTO.getRecipeCookMethod() != null &&
+        if (recipeUpdateDTO.getRecipeCookMethod() != null &&
                 !recipeUpdateDTO.getRecipeCookMethod().trim().isEmpty() &&
                 !tagService.isValidTag(recipeUpdateDTO.getRecipeCookMethod())) {
             throw new RuntimeException("유효하지 않는 요리방식입니다.: " + recipeUpdateDTO.getRecipeCookMethod());

--- a/src/main/java/com/be90z/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/be90z/domain/recipe/service/RecipeService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,18 +39,28 @@ public class RecipeService {
     private final RecipeTagService recipeTagService;
 
     //   AI로 레시피 분석
+//    @Transactional
+//    public RecipeAiResDTO createRecipeWithAi(RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
+//        String geminiResJson = geminiService.analyzeRecipe(
+//                recipeCreateFreeDTO.getRecipeName(),
+//                recipeCreateFreeDTO.getRecipeContent()
+//        );
+//        return geminiResParser.parseReponse(geminiResJson, RecipeAiResDTO.class);
+//    }
+
+//    레시피 분석 비동기로
     @Transactional
-    public RecipeAiResDTO createRecipeWithAi(RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
-        String geminiResJson = geminiService.analyzeRecipe(
+    public Mono<RecipeAiResDTO> createRecipeWithAiAsync (RecipeCreateFreeDTO recipeCreateFreeDTO) throws IOException {
+        return geminiService.analyzeRecipeAsync(
                 recipeCreateFreeDTO.getRecipeName(),
                 recipeCreateFreeDTO.getRecipeContent()
-        );
-
-//        AI 결과 Json > DTO 변환
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        RecipeAiResDTO recipeAiResDTO = objectMapper.readValue(geminiResJson, RecipeAiResDTO.class);
-//        return recipeAiResDTO;
-        return geminiResParser.parseReponse(geminiResJson, RecipeAiResDTO.class);
+        ).map(geminiResJson -> {
+            try {
+                return geminiResParser.parseReponse(geminiResJson, RecipeAiResDTO.class);
+            } catch (Exception e) {
+                throw new RuntimeException("JSON 파싱 실패 : ", e);
+            }
+        });
     }
 
     //    레시피 등록 - ai 후

--- a/src/main/java/com/be90z/external/gemini/config/RetryConfig.java
+++ b/src/main/java/com/be90z/external/gemini/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.be90z.external.gemini.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/com/be90z/external/gemini/prompt/GeminiRecipePrompt.java
+++ b/src/main/java/com/be90z/external/gemini/prompt/GeminiRecipePrompt.java
@@ -28,7 +28,7 @@ public class GeminiRecipePrompt {
                            - "DOUBLE": 2인분 \s
                            - "FAMILY": 4인분 이상
                         5. recipeTime: 조리 과정을 분석한 예상 소요시간 (1~180분 사이 정수)
-                        6. recipeCookMethod: 주요 조리 방법 (예: "볶기", "끓이기", "굽기", "튀기기", "찜", "무침", "계란말이" 등)
+                        6. recipeCookMethod: 주요 조리 방법 ("전자레인지", "에어프라이어", "프라이팬", "냄비", "오븐", "불 없이 요리") 중에서 선택해줘
                         7. ingredientsList: 내용에서 구체적으로 언급된 재료들만 추출
             
                         === 재료 추출 주의사항 ===
@@ -62,7 +62,7 @@ public class GeminiRecipePrompt {
                           "recipeCalories": 240,
                           "recipePeople": "DOUBLE",
                           "recipeTime": 25,
-                          "recipeCookMethod": "볶기",
+                          "recipeCookMethod": "프라이팬",
                           "ingredientsList": [
                             {
                               "ingredientName": "계란",

--- a/src/main/java/com/be90z/external/gemini/service/GeminiResParser.java
+++ b/src/main/java/com/be90z/external/gemini/service/GeminiResParser.java
@@ -4,6 +4,9 @@ import com.be90z.global.exception.JsonParsingException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -16,27 +19,46 @@ public class GeminiResParser {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
 //    레시피 작성 파싱
+    @Retryable(value = {JsonParsingException.class, JsonProcessingException.class},
+    maxAttempts = 3,
+    backoff = @Backoff(delay = 1000, multiplier = 2))
     public <T> T parseReponse(String geminiResponse, Class<T> targetClass) {
         try {
             String cleanedJson = cleanMarkdownFromJson(geminiResponse);
-            log.debug("정리된 Json: {}", cleanedJson);
+            log.debug("정리된 레시피 Json: {}", cleanedJson);
             return objectMapper.readValue(cleanedJson, targetClass);
         } catch (JsonProcessingException e) {
-            log.error("Gemini 응답 파싱 실패: {}", geminiResponse.substring(0, Math.min(200, geminiResponse.length())));
-            throw new RuntimeException("Gemini 응답을 파싱할 수 없습니다: " + e.getMessage(), e);
+            log.warn("Gemini 레시피 응답 파싱 실패, 재시도 예정 : {}", e.getMessage());
+            throw new JsonParsingException("Gemini 레시피 응답 파싱 실패: " + e.getMessage(), e);
         }
     }
 
 //    재료 추출 파싱
+    @Retryable(value = {JsonParsingException.class, JsonProcessingException.class},
+    maxAttempts = 3,
+    backoff = @Backoff(delay = 1000, multiplier = 2))
     public <T> T parseReponse(String geminiResponse, TypeReference<T> typeReference) {
         try {
             String cleanedJson = cleanMarkdownFromJson(geminiResponse);
-            log.debug("정리된 Json: {}", cleanedJson);
+            log.debug("정리된 재료 Json: {}", cleanedJson);
             return objectMapper.readValue(cleanedJson, typeReference);
         } catch (JsonProcessingException e) {
-            log.error("Gemini 응답 파싱 실패: {}", geminiResponse.substring(0, Math.min(200, geminiResponse.length())));
-            throw new RuntimeException("Gemini 응답을 파싱할 수 없습니다: " + e.getMessage(), e);
+            log.error("Gemini 재료 응답 파싱 실패, 재시도 예정 : {}", e.getMessage());
+            throw new JsonParsingException("Gemini 재료 응답을 파싱 실패: " + e.getMessage(), e);
         }
+    }
+
+    // 모든 재시도 실패 시 폴백 처리
+    @Recover
+    public <T> T recover(JsonParsingException ex, String geminiResponse, Class<T> targetClass) {
+        log.error("모든 재시도 실패, 기본값 반환. 오류: {}", ex.getMessage());
+        throw new RuntimeException("Gemini 응답 파싱에 실패했습니다: " + ex.getMessage(), ex);
+    }
+
+    @Recover
+    public <T> T recover(JsonParsingException ex, String geminiResponse, TypeReference<T> typeReference) {
+        log.error("모든 재시도 실패, 기본값 반환. 오류: {}", ex.getMessage());
+        throw new RuntimeException("Gemini 응답 파싱에 실패했습니다: " + ex.getMessage(), ex);
     }
 
     //    Json 응답에서 마크다운 코드 블록 제거

--- a/src/main/java/com/be90z/external/gemini/service/GeminiService.java
+++ b/src/main/java/com/be90z/external/gemini/service/GeminiService.java
@@ -29,37 +29,37 @@ public class GeminiService {
     private final GeminiIngredientPrompt geminiIngredientPrompt;
 
     //    레시피 분석
-    public String analyzeRecipe(String recipeName, String recipeContent) {
-        log.info("Gemini 레시피 분석 요청 - 제목: '{}', 내용 길이: {} 문자",
-                recipeName != null ? recipeName : "(제목 없음)", recipeContent.length());
-
-        try {
-            if (!geminiRecipePrompt.isValidInput(recipeName, recipeContent)) {
-                log.warn("레시피 입력이 유효하지 않음 - 내용 길이: {} 문자", recipeContent.length());
-                throw new IllegalArgumentException("레시피 내용이 너무 짧거나 깁니다");
-            }
-//            프롬프트 생성
-            String prompt = geminiRecipePrompt.createGeminiRecipePrompt(recipeName, recipeContent);
-
-//            Gemini API 호출
-            String responseGemini = callGeminiApi(prompt);
-
-            if (responseGemini != null && !responseGemini.trim().isEmpty()) {
-                log.info("Gemini 레시피 분석 성공");
-                return responseGemini;
-            } else {
-                log.warn("Gemini api 응답 비어있음");
-                return null;
-            }
-        } catch (IllegalArgumentException e) {
-            log.error("입력 검증 실패: {} ", e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("Gemini 레시피 분석 중 오류 발생: {}", e.getMessage(), e);
-            throw new RuntimeException("AI 레시피 분석 실패", e);
-        }
-
-    }
+//    public String analyzeRecipe(String recipeName, String recipeContent) {
+//        log.info("Gemini 레시피 분석 요청 - 제목: '{}', 내용 길이: {} 문자",
+//                recipeName != null ? recipeName : "(제목 없음)", recipeContent.length());
+//
+//        try {
+//            if (!geminiRecipePrompt.isValidInput(recipeName, recipeContent)) {
+//                log.warn("레시피 입력이 유효하지 않음 - 내용 길이: {} 문자", recipeContent.length());
+//                throw new IllegalArgumentException("레시피 내용이 너무 짧거나 깁니다");
+//            }
+////            프롬프트 생성
+//            String prompt = geminiRecipePrompt.createGeminiRecipePrompt(recipeName, recipeContent);
+//
+////            Gemini API 호출
+//            String responseGemini = callGeminiApi(prompt);
+//
+//            if (responseGemini != null && !responseGemini.trim().isEmpty()) {
+//                log.info("Gemini 레시피 분석 성공");
+//                return responseGemini;
+//            } else {
+//                log.warn("Gemini api 응답 비어있음");
+//                return null;
+//            }
+//        } catch (IllegalArgumentException e) {
+//            log.error("입력 검증 실패: {} ", e.getMessage());
+//            throw e;
+//        } catch (Exception e) {
+//            log.error("Gemini 레시피 분석 중 오류 발생: {}", e.getMessage(), e);
+//            throw new RuntimeException("AI 레시피 분석 실패", e);
+//        }
+//
+//    }
 
     //    재료 추출
     public String extractIngredientsForTags(String recipeName, String recipeContent) {

--- a/src/main/java/com/be90z/global/config/CorsConfig.java
+++ b/src/main/java/com/be90z/global/config/CorsConfig.java
@@ -9,7 +9,13 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")  // 모든 경로에 대해
-                .allowedOrigins("*")  // 모든 출처 허용 (개발용)
+                .allowedOrigins("https://mde.me.kr",
+                        "https://www.mde.me.kr",
+                        "https://api.mde.me.kr",
+                        "http://localhost:8080", // 로컬 개발용
+                        "http://3.37.33.223:8080", // 배포 서버 ip
+                        "https://3.37.33.223:8080" // https 배포 서버
+                )  // 도메인
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")  // 허용할 HTTP 메서드
                 .allowedHeaders("*")  // 모든 헤더 허용
                 .allowCredentials(false);  // 인증 정보 포함 안 함

--- a/src/main/java/com/be90z/global/config/SwaggerConfig.java
+++ b/src/main/java/com/be90z/global/config/SwaggerConfig.java
@@ -24,6 +24,9 @@ public class SwaggerConfig {
                                 .email("contact@be90z.com")))
                 .servers(List.of(
                         new Server()
+                                .url("http://3.37.33.223:8080")  // EC2 서버 추가
+                                .description("배포 서버"),
+                        new Server()
                                 .url("http://localhost:8080")
                                 .description("개발 서버")
                 ));


### PR DESCRIPTION
🌟개요
---
AI 레시피 분석 후 결과 json 파싱 에러를 수정했습니다.

🌐연결된 Issues
---
Closes #29 

📋작업사항
---
- GeminiService: 비동기 AI 레시피 분석 로직 수정
- RecipeController: AI 레시피 분석 API 엔드포인트 수정
- RecipeService: 레시피 분석 서비스 로직 개선
- GeminiRecipePrompt: 요리방식 고정 응답으로 프롬프트 수정
- GeminiResParser: AI 응답 파싱 시 재시도 로직 추가
- 배포 환경: 서버 추가 및 CORS 설정 수정
- RetryConfig: 재시도 설정 추가로 안정성 개선

✏️작성한 이슈 외 작업사항
---
- AI 응답 파싱 실패 시 재시도 메커니즘 구현
- 배포 서버 환경 설정 및 CORS 정책 수정

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
