### PR TITLE
feat: 마이페이지 정보 조회/수정 API TDD 구현

### DIFF
--- a/src/main/java/com/be90z/domain/user/controller/UserController.java
+++ b/src/main/java/com/be90z/domain/user/controller/UserController.java
@@ -1,0 +1,83 @@
+package com.be90z.domain.user.controller;
+
+import com.be90z.domain.user.dto.request.UserMypageUpdateReqDTO;
+import com.be90z.domain.user.dto.response.UserMypageResDTO;
+import com.be90z.domain.user.service.UserService;
+import com.be90z.global.util.AuthUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+@Tag(name = "User", description = "사용자 관련 API")
+public class UserController {
+
+    private final UserService userService;
+    private final AuthUtil authUtil;
+
+    @GetMapping("/mypage")
+    @Operation(summary = "마이페이지 정보 조회", description = "현재 사용자의 마이페이지 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 에러")
+    })
+    public ResponseEntity<UserMypageResDTO> getMypage(
+            @RequestHeader(value = "Authorization", required = false) String token) {
+        if (token == null) {
+            return ResponseEntity.status(401).build();
+        }
+        
+        Long userId = authUtil.getUserIdFromToken(token);
+        if (userId == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            UserMypageResDTO response = userService.getMypage(userId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/mypage")
+    @Operation(summary = "마이페이지 정보 수정", description = "현재 사용자의 마이페이지 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 에러")
+    })
+    public ResponseEntity<UserMypageResDTO> updateMypage(
+            @RequestHeader(value = "Authorization", required = false) String token,
+            @RequestBody UserMypageUpdateReqDTO request) {
+        
+        if (token == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Long userId = authUtil.getUserIdFromToken(token);
+        if (userId == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            UserMypageResDTO response = userService.updateMypage(userId, request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/be90z/domain/user/dto/request/UserMypageUpdateReqDTO.java
+++ b/src/main/java/com/be90z/domain/user/dto/request/UserMypageUpdateReqDTO.java
@@ -1,0 +1,14 @@
+package com.be90z.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserMypageUpdateReqDTO {
+    private String userName;
+    
+    public UserMypageUpdateReqDTO(String userName) {
+        this.userName = userName;
+    }
+}

--- a/src/main/java/com/be90z/domain/user/dto/response/UserMypageResDTO.java
+++ b/src/main/java/com/be90z/domain/user/dto/response/UserMypageResDTO.java
@@ -1,0 +1,18 @@
+package com.be90z.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserMypageResDTO {
+    private final String userName;
+    private final String email;
+    
+    public static UserMypageResDTO from(String userName, String email) {
+        return UserMypageResDTO.builder()
+                .userName(userName)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/be90z/domain/user/entity/User.java
+++ b/src/main/java/com/be90z/domain/user/entity/User.java
@@ -56,4 +56,11 @@ public class User {
         this.auth = auth != null ? auth : UserAuthority.USER;
         this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
     }
+    
+    public void updateNickname(String nickname) {
+        if (nickname == null) {
+            throw new IllegalArgumentException("Nickname cannot be null");
+        }
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/be90z/domain/user/service/UserService.java
+++ b/src/main/java/com/be90z/domain/user/service/UserService.java
@@ -1,0 +1,35 @@
+package com.be90z.domain.user.service;
+
+import com.be90z.domain.user.dto.request.UserMypageUpdateReqDTO;
+import com.be90z.domain.user.dto.response.UserMypageResDTO;
+import com.be90z.domain.user.entity.User;
+import com.be90z.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserMypageResDTO getMypage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        
+        return UserMypageResDTO.from(user.getNickname(), user.getEmail());
+    }
+
+    @Transactional
+    public UserMypageResDTO updateMypage(Long userId, UserMypageUpdateReqDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        
+        user.updateNickname(request.getUserName());
+        userRepository.save(user);
+        
+        return UserMypageResDTO.from(user.getNickname(), user.getEmail());
+    }
+}

--- a/src/test/java/com/be90z/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/be90z/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,127 @@
+package com.be90z.domain.user.controller;
+
+import com.be90z.domain.user.dto.request.UserMypageUpdateReqDTO;
+import com.be90z.domain.user.dto.response.UserMypageResDTO;
+import com.be90z.domain.user.service.UserService;
+import com.be90z.global.util.AuthUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private AuthUtil authUtil;
+
+    @Test
+    @DisplayName("마이페이지 정보 조회 성공")
+    @WithMockUser
+    void getMypage_Success() throws Exception {
+        // given
+        String token = "Bearer valid-jwt-token";
+        Long userId = 1L;
+        UserMypageResDTO expectedResponse = UserMypageResDTO.builder()
+                .userName("테스트유저")
+                .email("test@example.com")
+                .build();
+
+        when(authUtil.getUserIdFromToken(token)).thenReturn(userId);
+        when(userService.getMypage(userId)).thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/user/mypage")
+                        .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userName").value("테스트유저"))
+                .andExpect(jsonPath("$.email").value("test@example.com"));
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 조회 실패 - 토큰 없음")
+    void getMypage_Fail_NoToken() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/user/mypage"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 조회 실패 - 유효하지 않은 토큰")
+    void getMypage_Fail_InvalidToken() throws Exception {
+        // given
+        String invalidToken = "Bearer invalid-token";
+        when(authUtil.getUserIdFromToken(invalidToken)).thenReturn(null);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/user/mypage")
+                        .header("Authorization", invalidToken))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 수정 성공")
+    @WithMockUser
+    void updateMypage_Success() throws Exception {
+        // given
+        String token = "Bearer valid-jwt-token";
+        Long userId = 1L;
+        UserMypageUpdateReqDTO request = new UserMypageUpdateReqDTO("수정된유저명");
+        UserMypageResDTO expectedResponse = UserMypageResDTO.builder()
+                .userName("수정된유저명")
+                .email("test@example.com")
+                .build();
+
+        when(authUtil.getUserIdFromToken(token)).thenReturn(userId);
+        when(userService.updateMypage(eq(userId), any(UserMypageUpdateReqDTO.class)))
+                .thenReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/user/mypage")
+                        .with(csrf())
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userName").value("수정된유저명"))
+                .andExpect(jsonPath("$.email").value("test@example.com"));
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 수정 실패 - 토큰 없음")
+    @WithMockUser
+    void updateMypage_Fail_NoToken() throws Exception {
+        // given
+        UserMypageUpdateReqDTO request = new UserMypageUpdateReqDTO("수정된유저명");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/user/mypage")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/be90z/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/be90z/domain/user/service/UserServiceTest.java
@@ -1,0 +1,108 @@
+package com.be90z.domain.user.service;
+
+import com.be90z.domain.user.dto.request.UserMypageUpdateReqDTO;
+import com.be90z.domain.user.dto.response.UserMypageResDTO;
+import com.be90z.domain.user.entity.User;
+import com.be90z.domain.user.entity.UserAuthority;
+import com.be90z.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("마이페이지 정보 조회 성공")
+    void getMypage_Success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .userId(userId)
+                .provider("google")
+                .nickname("테스트유저")
+                .email("test@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        UserMypageResDTO result = userService.getMypage(userId);
+
+        // then
+        assertThat(result.getUserName()).isEqualTo("테스트유저");
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 조회 실패 - 사용자를 찾을 수 없음")
+    void getMypage_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getMypage(userId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 수정 성공")
+    void updateMypage_Success() {
+        // given
+        Long userId = 1L;
+        UserMypageUpdateReqDTO request = new UserMypageUpdateReqDTO("수정된유저명");
+        User existingUser = User.builder()
+                .userId(userId)
+                .provider("google")
+                .nickname("기존유저명")
+                .email("test@example.com")
+                .auth(UserAuthority.USER)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        UserMypageResDTO result = userService.updateMypage(userId, request);
+
+        // then
+        assertThat(result.getUserName()).isEqualTo("수정된유저명");
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    @DisplayName("마이페이지 정보 수정 실패 - 사용자를 찾을 수 없음")
+    void updateMypage_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        UserMypageUpdateReqDTO request = new UserMypageUpdateReqDTO("수정된유저명");
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateMypage(userId, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
🌟개요
---
TDD 방식으로 마이페이지 정보 조회 및 수정 API를 구현했습니다.

🌐연결된 Issues
---
관련 이슈: MDE004 마이 페이지 내 정보 조회/수정 API 구현

📋작업사항
---
- GET /api/v1/user/mypage: 내 정보 조회 (userName, email)
- POST /api/v1/user/mypage: 내 정보 수정 (nickname 변경)
- JWT 토큰 기반 사용자 인증 및 권한 검증
- Spring Security 통합 및 MockMvc 테스트
- UserController, UserService, DTO 클래스 구현
- 완전한 테스트 커버리지 (Controller 5개, Service 4개 테스트)

✏️작성한 이슈 외 작업사항
---
- User 엔티티에 updateNickname 메서드 추가
- 예외 처리 및 입력 검증 로직 구현
- RESTful API 설계 원칙 준수

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?