### PR TITLE
fix: Mission 엔티티 및 서비스 버그 수정

### DIFF
--- a/src/main/java/com/be90z/domain/mission/entity/Mission.java
+++ b/src/main/java/com/be90z/domain/mission/entity/Mission.java
@@ -55,7 +55,7 @@ public class Mission {
         this.missionName = missionName;
         this.missionContent = missionContent;
         this.missionStatus = missionStatus != null ? missionStatus : MissionStatus.ACTIVE;
-        this.missionGoalCount = missionGoalCount;
+        this.missionGoalCount = missionGoalCount != null ? missionGoalCount : 1;
         this.startDate = startDate;
         this.endDate = endDate;
         this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();

--- a/src/main/java/com/be90z/domain/mission/service/MissionService.java
+++ b/src/main/java/com/be90z/domain/mission/service/MissionService.java
@@ -176,7 +176,8 @@ public class MissionService {
                 .orElseThrow(() -> new NotFoundException("Mission not found with code: " + missionCode));
         
         // 명세서에 맞는 페이로드: {missionName, missionContent}
-//        mission.updateMission(request.getMissionName(), request.getMissionContent());
+        mission.updateMission(request.getMissionName(), request.getMissionContent(), 
+                             null, null, null);
         
         Mission updatedMission = missionRepository.save(mission);
         

--- a/src/test/java/com/be90z/domain/mission/entity/MissionTest.java
+++ b/src/test/java/com/be90z/domain/mission/entity/MissionTest.java
@@ -88,8 +88,8 @@ class MissionTest {
         String newMissionName = "수정된 미션명";
         String newMissionContent = "수정된 내용";
         
-        // when - 새로운 시그니처 사용: updateMission(missionName, missionContent)
-        mission.updateMission(newMissionName, newMissionContent);
+        // when - 실제 시그니처 사용: updateMission(missionName, missionContent, startDate, endDate, goalCount)
+        mission.updateMission(newMissionName, newMissionContent, null, null, null);
         
         // then
         assertThat(mission.getMissionName()).isEqualTo(newMissionName);


### PR DESCRIPTION
🌟개요
---
Mission 엔티티의 기본값 설정 오류와 MissionService의 업데이트 로직 버그를 수정했습니다.

🌐연결된 Issues
---
테스트 실패 해결을 위한 Mission 관련 버그 수정

📋작업사항
---
- Mission 엔티티 missionGoalCount 기본값 1로 설정
- MissionService.updateMission 메서드 호출 로직 활성화
- MissionTest 업데이트 메서드 테스트 수정
- 실패하던 테스트들이 모두 통과하도록 수정

✏️작성한 이슈 외 작업사항
---
- Mission.java: missionGoalCount null 체크 후 기본값 1 설정
- MissionService.java: 주석 처리된 updateMission 호출부 수정
- MissionTest.java: 올바른 파라미터로 updateMission 호출하도록 수정
- 전체 테스트 성공률 100% 달성

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?